### PR TITLE
Target host port methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 the [PEP 440 version scheme](https://peps.python.org/pep-0440/#version-scheme).
 
+## v0.5.0 - 2024-03-08
+### Added
+- Implementation for \[NetworkProtocol\] getter in TargetHostPorts. #6
+- PortScanDataDict.get_open_service_ports(). #6
+
 
 ## v0.4.0 - 2024-03-14
 ### Added

--- a/agentpluginapi/target_host.py
+++ b/agentpluginapi/target_host.py
@@ -7,6 +7,7 @@ from monkeytypes import (
     MutableInfectionMonkeyBaseModel,
     NetworkPort,
     NetworkProtocol,
+    NetworkService,
     OperatingSystem,
     PortStatus,
 )
@@ -33,6 +34,9 @@ class PortScanDataDict(UserDict[NetworkPort, PortScanData]):
         return {
             port for port, port_scan_data in self.data.items() if port_scan_data.status == status
         }
+
+    def get_open_service_ports(self, service: NetworkService) -> Set[NetworkPort]:
+        return {port for port in self.open if self[port].service == service}
 
 
 class TargetHostPorts(MutableInfectionMonkeyBaseModel):

--- a/agentpluginapi/target_host.py
+++ b/agentpluginapi/target_host.py
@@ -3,7 +3,13 @@ from collections import UserDict
 from ipaddress import IPv4Address
 from typing import Optional, Set
 
-from monkeytypes import MutableInfectionMonkeyBaseModel, NetworkPort, OperatingSystem, PortStatus
+from monkeytypes import (
+    MutableInfectionMonkeyBaseModel,
+    NetworkPort,
+    NetworkProtocol,
+    OperatingSystem,
+    PortStatus,
+)
 from pydantic import ConfigDict, Field, TypeAdapter, field_serializer
 
 from .port_scan_data import PortScanData
@@ -38,6 +44,14 @@ class TargetHostPorts(MutableInfectionMonkeyBaseModel):
     @field_serializer("tcp_ports", "udp_ports", when_used="json")
     def dump_ports(self, v):
         return dict(v)
+
+    def __getitem__(self, protocol: NetworkProtocol):
+        if protocol == NetworkProtocol.TCP:
+            return self.tcp_ports
+        elif protocol == NetworkProtocol.UDP:
+            return self.udp_ports
+        else:
+            raise KeyError(f"Invalid protocol: {protocol}")
 
 
 class TargetHost(MutableInfectionMonkeyBaseModel):

--- a/tests/test_target_host.py
+++ b/tests/test_target_host.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import pytest
-from monkeytypes import NetworkPort, NetworkProtocol, PortStatus
+from monkeytypes import NetworkPort, NetworkProtocol, NetworkService, PortStatus
 
 from agentpluginapi import PortScanData, PortScanDataDict, TargetHost, TargetHostPorts
 
@@ -119,3 +119,27 @@ def test_target_host_ports__getitem__keyerror(protocol: Any):
 
     with pytest.raises(KeyError):
         thp[protocol]
+
+
+@pytest.mark.parametrize(
+    "service, expected_port", ((NetworkService.HTTP, 1), (NetworkService.SSH, 3))
+)
+def test_get_open_service_ports(service: NetworkService, expected_port: int):
+    psdd = PortScanDataDict(
+        {
+            NetworkPort(1): PortScanData(
+                port=1, status=PortStatus.OPEN, service=NetworkService.HTTP
+            ),
+            NetworkPort(2): PortScanData(
+                port=2, status=PortStatus.CLOSED, service=NetworkService.HTTP
+            ),
+            NetworkPort(3): PortScanData(
+                port=3, status=PortStatus.OPEN, service=NetworkService.SSH
+            ),
+        }
+    )
+
+    open_service_ports = psdd.get_open_service_ports(service)
+
+    assert len(open_service_ports) == 1
+    assert open_service_ports == {NetworkPort(expected_port)}

--- a/vulture_allowlist.py
+++ b/vulture_allowlist.py
@@ -58,6 +58,7 @@ PortScanData.banner
 PortScanData.service
 
 PortScanDataDict.closed
+PortScanDataDict.get_open_service_ports
 
 TargetHost
 TargetHost.ip


### PR DESCRIPTION
Adds helper/filter methods to PortScanDataDict. This will allow us to remove https://github.com/guardicode/plugintoolbox/blob/dev/plugintoolbox/network_utils.py.